### PR TITLE
Reverse proxy starting process impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,6 +977,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3182,6 +3192,7 @@ dependencies = [
  "custom_derive",
  "dirs",
  "enum_derive",
+ "fs2",
  "futures",
  "local_ipaddress",
  "rand 0.8.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { version = "0.2", features = ["io-std", "io-util", "fs", "rt-core", "rt
 dirs = "4.0"
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1.0"
+fs2 = "0.4"
 
 [workspace]
 members = [ "crates/*" ]

--- a/crates/ya-http-proxy-client/src/lib.rs
+++ b/crates/ya-http-proxy-client/src/lib.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 pub mod web;
 
 pub mod api;

--- a/crates/ya-http-proxy-client/src/web.rs
+++ b/crates/ya-http-proxy-client/src/web.rs
@@ -1,16 +1,31 @@
 use http::{Method, Uri};
 use serde::{Deserialize, Serialize};
+use std::env;
+use std::str::FromStr;
 
 use crate::model::ErrorResponse;
 use crate::{Error, Result};
 
-/// Body size limit: 8 MiB
+pub const MANAGEMENT_API_URL_ENV_VAR: &str = "MANAGEMENT_API_URL";
+pub const DEFAULT_MANAGEMENT_API_URL: &str = "http://127.0.0.1:1234";
 const MAX_BODY_SIZE: usize = 8 * 1024 * 1024;
 
 #[derive(Clone)]
 pub struct WebClient {
     url: Uri,
     inner: awc::Client,
+}
+
+impl Default for WebClient {
+    fn default() -> Self {
+        let url = env::var(MANAGEMENT_API_URL_ENV_VAR)
+            .unwrap_or_else(|_| DEFAULT_MANAGEMENT_API_URL.into());
+
+        WebClient {
+            url: Uri::from_str(url.as_str()).unwrap_or_default(),
+            ..Default::default()
+        }
+    }
 }
 
 impl WebClient {

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,0 +1,57 @@
+use fs2::FileExt;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+pub const LOCK_FILE_EXT: &str = ".lock";
+
+pub fn with_lock_ext<P: AsRef<Path>>(path: P) -> PathBuf {
+    let mut path = path.as_ref().to_owned();
+    path.push(LOCK_FILE_EXT);
+    path
+}
+
+pub struct LockFile {
+    path: PathBuf,
+    file: Option<File>,
+}
+
+impl LockFile {
+    pub fn new<P: AsRef<Path>>(path: P) -> Self {
+        Self {
+            path: path.as_ref().to_path_buf(),
+            file: None,
+        }
+    }
+
+    pub fn is_locked(&self) -> bool {
+        self.file.is_some()
+    }
+
+    pub fn lock(&mut self) -> std::io::Result<()> {
+        let file = if self.path.is_file() {
+            File::open(&self.path)?
+        } else {
+            File::create(&self.path)?
+        };
+
+        file.try_lock_exclusive()?;
+        self.file.replace(file);
+
+        Ok(())
+    }
+
+    pub fn unlock(&mut self) -> std::io::Result<()> {
+        if let Some(f) = self.file.take() {
+            f.unlock()?;
+            std::fs::remove_file(&self.path)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Drop for LockFile {
+    fn drop(&mut self) {
+        let _ = self.unlock();
+    }
+}


### PR DESCRIPTION
PR is related to this [issue](https://github.com/golemfactory/ya-runtime-basic-auth/issues/13). It enables reverse proxy process startup. The proxy binary is guarded via a lock file when starting up.