### PR TITLE
Plain HTTP mode

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,6 +62,12 @@ jobs:
         with:
           command: clippy
 
+      - name: Clippy proxy binary
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path crates/ya-http-proxy/Cargo.toml --bin ya-http-proxy --features bin
+
       - name: Test
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3102,7 +3102,6 @@ dependencies = [
  "jemallocator",
  "log",
  "openssl",
- "pin-project-lite 0.2.8",
  "routerify",
  "rustls",
  "rustls-pemfile",

--- a/crates/ya-http-proxy-model/src/addr.rs
+++ b/crates/ya-http-proxy-model/src/addr.rs
@@ -1,0 +1,68 @@
+use std::fmt::{Display, Formatter};
+use std::net::SocketAddr;
+use std::ops::Add;
+
+use serde::{de, Deserialize, Serialize};
+
+use crate::deser::one_or_many::OneOrManyVisitor;
+
+/// Socket address collection wrapper
+#[derive(Default, Clone, Debug, PartialEq, Eq, Hash, Serialize)]
+pub struct Addresses(pub Vec<SocketAddr>);
+
+impl Addresses {
+    pub fn to_vec(&self) -> Vec<SocketAddr> {
+        self.0.clone()
+    }
+}
+
+impl<'de> Deserialize<'de> for Addresses {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let mut addrs: Vec<SocketAddr> =
+            deserializer.deserialize_any(OneOrManyVisitor::<SocketAddr>::default())?;
+        addrs.sort();
+        addrs.dedup();
+        Ok(Addresses(addrs.into_iter().collect()))
+    }
+}
+
+impl Add for Addresses {
+    type Output = Self;
+
+    fn add(mut self, rhs: Self) -> Self {
+        self.0.extend(rhs.0);
+        self.0.sort();
+        self.0.dedup();
+        self
+    }
+}
+
+impl From<SocketAddr> for Addresses {
+    #[inline]
+    fn from(addr: SocketAddr) -> Self {
+        Self(vec![addr])
+    }
+}
+
+impl From<Vec<SocketAddr>> for Addresses {
+    #[inline]
+    fn from(vec: Vec<SocketAddr>) -> Self {
+        Self(vec)
+    }
+}
+
+impl Display for Addresses {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[")?;
+        for (i, addr) in self.0.iter().enumerate() {
+            if i != 0 {
+                write!(f, ", ")?;
+            }
+            addr.fmt(f)?;
+        }
+        write!(f, "]")
+    }
+}

--- a/crates/ya-http-proxy-model/src/lib.rs
+++ b/crates/ya-http-proxy-model/src/lib.rs
@@ -1,4 +1,6 @@
+mod addr;
 pub mod deser;
 mod model;
 
+pub use addr::*;
 pub use model::*;

--- a/crates/ya-http-proxy-model/src/model.rs
+++ b/crates/ya-http-proxy-model/src/model.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -8,7 +7,7 @@ use http::uri::Uri;
 use serde::{Deserialize, Serialize};
 use strum::{EnumString, EnumVariantNames, IntoStaticStr};
 
-use crate::deser;
+use crate::{deser, Addresses};
 
 /// Authorization configuration
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -60,8 +59,11 @@ pub struct CreateService {
     pub name: String,
     #[serde(default)]
     pub server_name: Vec<String>,
-    /// Listening address
-    pub bind: SocketAddr,
+    /// HTTPS listening addresses
+    #[serde(alias = "bind")]
+    pub bind_https: Option<Addresses>,
+    /// HTTP listening addresses
+    pub bind_http: Option<Addresses>,
     /// Certificate configuration
     pub cert: Option<CreateServiceCert>,
     /// Authorization options
@@ -78,6 +80,16 @@ pub struct CreateService {
     pub cpu_threads: Option<usize>,
     /// Forwarding options
     pub user: Option<CreateServiceUser>,
+}
+
+impl CreateService {
+    pub fn addresses(&self) -> Addresses {
+        let addrs = self.bind_https.clone().unwrap_or_default();
+        match self.bind_http.clone() {
+            Some(a) => addrs + a,
+            _ => addrs,
+        }
+    }
 }
 
 /// HTTP request forward options

--- a/crates/ya-http-proxy/Cargo.toml
+++ b/crates/ya-http-proxy/Cargo.toml
@@ -35,7 +35,6 @@ futures = { version = "0.3" }
 hyper = { version = "0.14", features = ["full"] }
 hyper-rustls = { version = "0.23", features = ["http2"] }
 log = { version =  "0.4" }
-pin-project-lite = { version = "0.2" }
 routerify = { version = "3.0" }
 rustls = { version = "0.20" }
 rustls-pemfile = { version = "0.2" }

--- a/crates/ya-http-proxy/src/api.rs
+++ b/crates/ya-http-proxy/src/api.rs
@@ -87,7 +87,8 @@ fn router(manager: ProxyManager) -> routerify::Result<Router<Body, HandlerError>
         .get(
             "/services/:service/users/:user/endpoints/stats",
             get_user_endpoint_stats,
-        );
+        )
+        .post("/control/shutdown", post_shutdown);
 
     builder.err_handler(err_handler).build()
 }
@@ -145,7 +146,7 @@ where
 {
     fn from(e: T) -> Self {
         match Error::from(e) {
-            e @ Error::Proxy(ProxyError::AlreadyExists(_)) => Self::Conflict(e),
+            e @ Error::Proxy(ProxyError::AlreadyRunning(_)) => Self::Conflict(e),
             e @ Error::Service(ServiceError::AlreadyExists { .. }) => Self::Conflict(e),
             e @ Error::User(UserError::AlreadyExists(_)) => Self::Conflict(e),
             e => Self::BadRequest(e),

--- a/crates/ya-http-proxy/src/api/handler.rs
+++ b/crates/ya-http-proxy/src/api/handler.rs
@@ -140,6 +140,7 @@ pub async fn get_user_stats(req: Request<Body>) -> HandlerResult {
         .get(username)
         .copied()
         .ok_or_else(|| UserError::NotFound(username.to_string()))?;
+
     Response::object(&model::UserStats { requests })
 }
 
@@ -155,7 +156,16 @@ pub async fn get_user_endpoint_stats(req: Request<Body>) -> HandlerResult {
         .user_endpoint
         .get(username)
         .ok_or_else(|| UserError::NotFound(username.to_string()))?;
+
     Response::object(&model::UserEndpointStats(endpoint_requests.clone()))
+}
+
+/// Shuts down the proxy
+pub async fn post_shutdown(req: Request<Body>) -> HandlerResult {
+    let manager: &ProxyManager = req.data().unwrap();
+    manager.stop().await;
+
+    Response::object(&())
 }
 
 trait ResponseExt<B, E> {

--- a/crates/ya-http-proxy/src/bin.rs
+++ b/crates/ya-http-proxy/src/bin.rs
@@ -40,7 +40,7 @@ struct Cli {
 impl Cli {
     fn update_conf(&self, conf: &mut ProxyConf) {
         if let Some(addr) = self.default_addr {
-            conf.server.addr = addr;
+            conf.server.bind_https = Some(addr.into());
         }
         if let Some(ref path) = self.default_cert {
             conf.server.server_cert.server_cert_store_path = Some(path.clone());

--- a/crates/ya-http-proxy/src/error.rs
+++ b/crates/ya-http-proxy/src/error.rs
@@ -1,5 +1,6 @@
 use std::net::SocketAddr;
 use std::path::Path;
+use ya_http_proxy_model::Addresses;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -52,8 +53,8 @@ pub enum ManagementError {
 
 #[derive(thiserror::Error, Debug)]
 pub enum ProxyError {
-    #[error("Proxy is already running on {}", .0.to_string())]
-    AlreadyExists(std::net::SocketAddr),
+    #[error("Proxy is already running on addresses: {0}")]
+    AlreadyRunning(Addresses),
     #[error("Proxy runtime error: {0}")]
     Runtime(String),
     #[error("Proxy configuration error: {0}")]

--- a/crates/ya-http-proxy/src/proxy/stream.rs
+++ b/crates/ya-http-proxy/src/proxy/stream.rs
@@ -1,4 +1,4 @@
-//! Adaptation of `hyper::server::tcp::addr_stream::AddrStream` for use with TLS
+//! `hyper_rustls::stream::MaybeHttpsStream` w/ a source socket address
 
 use std::io;
 use std::net::SocketAddr;
@@ -7,77 +7,105 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use hyper::client::connect::{Connected, Connection};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::TcpStream;
 use tokio_rustls::server::TlsStream;
 
-pin_project_lite::pin_project! {
-    #[derive(Debug)]
-    pub struct TlsAddrStream {
-        #[pin]
-        inner: TlsStream<TcpStream>,
+pub type HttpStream = HttpStreamKind<TcpStream>;
+
+pub enum HttpStreamKind<T> {
+    Plain {
+        inner: T,
         remote_addr: SocketAddr,
-    }
+    },
+    Tls {
+        inner: TlsStream<T>,
+        remote_addr: SocketAddr,
+    },
 }
 
-impl TlsAddrStream {
-    pub fn new(tcp: TlsStream<TcpStream>, addr: SocketAddr) -> TlsAddrStream {
-        TlsAddrStream {
-            inner: tcp,
+impl<T> HttpStreamKind<T> {
+    pub fn plain(inner: T, addr: SocketAddr) -> Self {
+        HttpStreamKind::Plain {
+            inner,
+            remote_addr: addr,
+        }
+    }
+
+    pub fn tls(inner: TlsStream<T>, addr: SocketAddr) -> Self {
+        HttpStreamKind::Tls {
+            inner,
             remote_addr: addr,
         }
     }
 
     #[inline]
     pub fn remote_addr(&self) -> SocketAddr {
-        self.remote_addr
-    }
-
-    #[allow(unused)]
-    #[inline]
-    pub fn into_inner(self) -> TlsStream<TcpStream> {
-        self.inner
-    }
-
-    #[allow(unused)]
-    pub fn poll_peek(
-        &mut self,
-        cx: &mut Context<'_>,
-        buf: &mut tokio::io::ReadBuf<'_>,
-    ) -> Poll<io::Result<usize>> {
-        self.inner.get_mut().0.poll_peek(cx, buf)
+        match self {
+            Self::Plain { remote_addr, .. } => *remote_addr,
+            Self::Tls { remote_addr, .. } => *remote_addr,
+        }
     }
 }
 
-impl AsyncRead for TlsAddrStream {
+impl<T: AsyncRead + AsyncWrite + Connection + Unpin> Connection for HttpStreamKind<T> {
+    fn connected(&self) -> Connected {
+        match self {
+            HttpStreamKind::Plain { inner, .. } => inner.connected(),
+            HttpStreamKind::Tls { inner, .. } => {
+                let (tcp, tls) = inner.get_ref();
+                if tls.alpn_protocol() == Some(b"h2") {
+                    tcp.connected().negotiated_h2()
+                } else {
+                    tcp.connected()
+                }
+            }
+        }
+    }
+}
+
+impl<T: AsyncRead + AsyncWrite + Unpin> AsyncRead for HttpStreamKind<T> {
     #[inline]
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        self.project().inner.poll_read(cx, buf)
+        match Pin::get_mut(self) {
+            Self::Plain { inner, .. } => Pin::new(inner).poll_read(cx, buf),
+            Self::Tls { inner, .. } => Pin::new(inner).poll_read(cx, buf),
+        }
     }
 }
 
-impl AsyncWrite for TlsAddrStream {
+impl<T: AsyncRead + AsyncWrite + Unpin> AsyncWrite for HttpStreamKind<T> {
     #[inline]
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        self.project().inner.poll_write(cx, buf)
+        match Pin::get_mut(self) {
+            Self::Plain { inner, .. } => Pin::new(inner).poll_write(cx, buf),
+            Self::Tls { inner, .. } => Pin::new(inner).poll_write(cx, buf),
+        }
     }
 
     #[inline]
-    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Poll::Ready(Ok(()))
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match Pin::get_mut(self) {
+            Self::Plain { inner, .. } => Pin::new(inner).poll_flush(cx),
+            Self::Tls { inner, .. } => Pin::new(inner).poll_flush(cx),
+        }
     }
 
     #[inline]
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        self.project().inner.poll_shutdown(cx)
+        match Pin::get_mut(self) {
+            Self::Plain { inner, .. } => Pin::new(inner).poll_shutdown(cx),
+            Self::Tls { inner, .. } => Pin::new(inner).poll_shutdown(cx),
+        }
     }
 
     #[inline]
@@ -86,18 +114,28 @@ impl AsyncWrite for TlsAddrStream {
         cx: &mut Context<'_>,
         bufs: &[io::IoSlice<'_>],
     ) -> Poll<io::Result<usize>> {
-        self.project().inner.poll_write_vectored(cx, bufs)
+        match Pin::get_mut(self) {
+            Self::Plain { inner, .. } => Pin::new(inner).poll_write_vectored(cx, bufs),
+            Self::Tls { inner, .. } => Pin::new(inner).poll_write_vectored(cx, bufs),
+        }
     }
 
     #[inline]
     fn is_write_vectored(&self) -> bool {
-        self.inner.is_write_vectored()
+        match self {
+            Self::Plain { inner, .. } => inner.is_write_vectored(),
+            Self::Tls { inner, .. } => inner.is_write_vectored(),
+        }
     }
 }
 
 #[cfg(unix)]
-impl AsRawFd for TlsAddrStream {
+impl<T: AsRawFd> AsRawFd for HttpStreamKind<T> {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
-        self.inner.as_raw_fd()
+        match self {
+            Self::Plain { inner, .. } => inner.as_raw_fd(),
+            Self::Tls { inner, .. } => inner.as_raw_fd(),
+        }
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -20,7 +20,7 @@ pub async fn spawn(api: ManagementApi, data_dir: PathBuf) -> anyhow::Result<()> 
 
     loop {
         if Instant::now() - started >= TIMEOUT {
-            anyhow::bail!("Proxy timed out after {}s", TIMEOUT.as_secs_f32());
+            anyhow::bail!("proxy timed out after {}s", TIMEOUT.as_secs_f32());
         }
 
         state = match std::mem::replace(&mut state, ProxyState::Poisoned) {
@@ -107,7 +107,7 @@ fn spawn_detached_command(mut command: Command) -> anyhow::Result<()> {
         use nix::unistd::{fork, setsid, ForkResult};
         use std::process::exit;
 
-        match unsafe { fork().expect("Failed to fork process") } {
+        match unsafe { fork().expect("failed to fork the process") } {
             ForkResult::Parent { child } => {
                 let _ = waitpid(Some(child), None);
             }


### PR DESCRIPTION
- support plain HTTP communication
- HTTPS endpoint is now optional, but either HTTP or HTTPS is required
- support listening on multiple socket addresses
- proxy shutdown endpoint